### PR TITLE
feat: Volume mount files via app helm chart

### DIFF
--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
             {{- toYaml .Values.container.args | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.container.volumeMounts | nindent 12 }}
+          {{- if .Values.mount.files }}
+          - name: mounted-files
+            mountPath: .Values.mount.path
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: "{{ include "app.fullname" . }}"
@@ -101,6 +105,11 @@ spec:
         - name: telegraf-conf
           configMap:
             name: {{ template "app.fullname" . }}-telegraf
+        {{- end }}
+        {{- if .Values.mount.files }}
+        - name: mounted-files
+          configMap:
+            name: {{ template "app.fullname" . }}-files
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/app/templates/file-configmap.yaml
+++ b/stable/app/templates/file-configmap.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.mount.files }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "app.fullname" . }}-files"
+  namespace: "{{ include "app.namespace" . }}"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/resource-policy": "keep"
+data:
+{{- range $k, $v := .Values.mount.files }}
+  {{ $k }}: |
+{{ $v | indent 4}}
+{{- end }}
+{{ end }}

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -165,3 +165,10 @@ autoscaling:
   maxReplicas: 2
   targetMemory: 80
   targetCPU: 80
+
+mount:
+  path: /etc/some_path
+  files:
+    # -- can be set using --set-file mount.files.config\\.yaml=./config.yaml
+    config.yaml: |
+      plan: works


### PR DESCRIPTION
This PR adds functionality to create configmaps from files and volume mount them. This is a common use case when for applications that read their configs from a particular file or path in the deployment.