### PR TITLE
fix: typo in the name of the feature

### DIFF
--- a/stable/app/templates/hpa.yaml
+++ b/stable/app/templates/hpa.yaml
@@ -34,7 +34,7 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPU }}
     {{- end }}
-  {{- if .Values.autoscaling.behaviour }}
-  behaviour: {{ .Values.autoscaling.behaviour | toYaml | nindent 4 }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior: {{ .Values.autoscaling.behavior | toYaml | nindent 4 }}
   {{- end}}
 {{- end }}


### PR DESCRIPTION
- Typo in the behavior key