### PR TITLE
Add support for pod disruption budget

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.5.5

--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.5
+version: 0.6.0

--- a/stable/app/README.md
+++ b/stable/app/README.md
@@ -91,6 +91,9 @@ The following table lists the configurable parameters of the Siren chart and the
 | telegraf.containerPort                | int    | `8125`                                                                                        |                                                                      |
 | telegraf.protocol                     | string | `UDP`                                                                                         |                                                                      |
 | telegraf.config                       | string | `""`                                                                                          | telegraf config file content                                         |
+| pdb.enabled | bool | `false` | Whether to enable pod disruption budget on the release | 
+| pdb.minAvailable | int | `0` | minimum number of pods that should be available according to PDB |
+| pdb.maxUnavailable | int | `` | maximum number of pods that can be unavailable according to PDB |
 
 ---
 

--- a/stable/app/templates/cron.yaml
+++ b/stable/app/templates/cron.yaml
@@ -18,6 +18,7 @@ spec:
       template:
         metadata:
           labels:
+            app.kubernetes.io/type: cronjob
         {{- $appSelectorLabels | nindent 12 }}
         spec:
           containers:

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
+      app.kubernetes.io/type: deployment
       {{- include "app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -21,6 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
+        app.kubernetes.io/type: deployment
         {{- include "app.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -18,7 +18,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/type: job
+        {{- include "app.selectorLabels" . | nindent 8 }}     
     spec:
       restartPolicy: Never
       containers:

--- a/stable/app/templates/pdb.yaml
+++ b/stable/app/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "app.fullname" . }}-pdb
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 0 }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/stable/app/templates/pdb.yaml
+++ b/stable/app/templates/pdb.yaml
@@ -9,7 +9,9 @@ spec:
   {{- if .Values.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end }}
+  {{- if not .Values.pdb.maxUnavailable }}
   minAvailable: {{ .Values.pdb.minAvailable | default 0 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}

--- a/stable/app/templates/pdb.yaml
+++ b/stable/app/templates/pdb.yaml
@@ -14,5 +14,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
+      app.kubernetes.io/type: deployment
       {{- include "app.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/stable/app/templates/service.yaml
+++ b/stable/app/templates/service.yaml
@@ -19,4 +19,5 @@ spec:
       name: {{ $port.name }}
     {{- end }}
   selector:
+    app.kubernetes.io/type: deployment
     {{- include "app.selectorLabels" . | nindent 4 }}

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -165,3 +165,8 @@ autoscaling:
   maxReplicas: 2
   targetMemory: 80
   targetCPU: 80
+
+pdb:
+  enabled: false
+  # minAvailable: 0
+  # maxUnavailable: 1


### PR DESCRIPTION
Added support for three fields
1. enabled: Default `false` for backward compatibility
2. minAvailable: Default `0` default value doesn't actually impact anything
3. maxUnavailable: No default value. 