### PR TITLE
fix: namespace referenece in cronjob

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2

--- a/stable/app/templates/cron.yaml
+++ b/stable/app/templates/cron.yaml
@@ -2,12 +2,13 @@
 {{- $fullName := include "app.fullname" . -}}
 {{- $appLabels := include "app.labels" . -}}
 {{- $appSelectorLabels := include "app.selectorLabels" . -}}
+{{- $appNamespace := include "app.namespace" . -}}
 {{- range $i, $job := .Values.cron.jobs }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ $fullName | trunc 24 }}-{{ $i }}-{{ $job.name | trunc 24}}"
-  namespace: "{{ include "app.namespace" . }}"
+  namespace: "{{ $appNamespace }}"
   labels:
     {{- $appLabels | nindent 4 }}
 spec:


### PR DESCRIPTION
### Context
1. cron job deployments were failing due to namespace reference issue.

### Fix
1. Extracted namespace variable out of the for loop for correct reference