### PR TITLE
feat: add terminationGracePeriodSeconds to app chart

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.7.0

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -116,6 +116,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds:
-        {{- toYaml . | nindent 8 }}
+      terminationGracePeriodSeconds: {{ . }}
       {{- end }}

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -115,3 +115,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -23,7 +23,8 @@ additionalLabels: {}
 podSecurityContext: {}
 # -- Eg: fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # -- capabilities:
   # --   drop:
   # --   - ALL
@@ -48,7 +49,8 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # -- kubernetes.io/ingress.class: nginx
     # -- kubernetes.io/tls-acme: "true"
   hosts:
@@ -66,7 +68,8 @@ ingress:
   # --    hosts:
   # --      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # -- We usually recommend not to specify default resources and to leave this as a conscious
   # -- choice for the user. This also increases chances charts run on environments with little
   # -- resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -131,7 +134,8 @@ container:
 
 config: {}
 
-secretConfig: {}
+secretConfig:
+  {}
   # -- Example: database connection details can go under secret config
   # DB_HOST: localhost
   # DB_NAME: app
@@ -169,3 +173,5 @@ autoscaling:
   maxReplicas: 2
   targetMemory: 80
   targetCPU: 80
+
+terminationGracePeriodSeconds: 30

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -170,4 +170,4 @@ autoscaling:
   targetMemory: 80
   targetCPU: 80
 
-terminationGracePeriodSeconds: 30
+# terminationGracePeriodSeconds: 30

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -23,8 +23,7 @@ additionalLabels: {}
 podSecurityContext: {}
 # -- Eg: fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # -- capabilities:
   # --   drop:
   # --   - ALL
@@ -49,8 +48,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # -- kubernetes.io/ingress.class: nginx
     # -- kubernetes.io/tls-acme: "true"
   hosts:
@@ -68,8 +66,7 @@ ingress:
   # --    hosts:
   # --      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # -- We usually recommend not to specify default resources and to leave this as a conscious
   # -- choice for the user. This also increases chances charts run on environments with little
   # -- resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -134,8 +131,7 @@ container:
 
 config: {}
 
-secretConfig:
-  {}
+secretConfig: {}
   # -- Example: database connection details can go under secret config
   # DB_HOST: localhost
   # DB_NAME: app


### PR DESCRIPTION
This PR will add `terminationGracePeriodSeconds` to the pod spec.
By default, the value is 30s, but sometimes the service will take longer to shut down, so adding this will customize the shutdown wait time.
I used [kong deployment chart template](https://github.com/Kong/charts/blob/main/charts/kong/templates/deployment.yaml#L306) as reference
