### PR TITLE
feat: add support for service account in CronJobs inside app chart

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1

--- a/stable/app/templates/cron.yaml
+++ b/stable/app/templates/cron.yaml
@@ -35,6 +35,9 @@ spec:
                 - secretRef:
                     name: {{ $fullName }}
           restartPolicy: {{ $job.restartPolicy }}
+          {{- if $.Values.serviceAccount.enabled }}
+          serviceAccountName: {{ include "app.fullname" $ }}
+          {{- end }}
 ---
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description 

Allow specifying service account name in cron jobs.

# Testing 

The values.yaml was changed with this change:

```yaml
cron:
  enabled: true
serviceAccount:
  enabled: true
``` 

And generated the manifests via `helm template stable/app --dry-run`
