### PR TITLE
feat(frontier): update app chart and add frontier-worker deployment

### DIFF
--- a/stable/frontier/Chart.lock
+++ b/stable/frontier/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
 - name: app
   repository: https://raystack.github.io/charts/
-  version: 0.5.3
+  version: 0.8.0
 - name: app
   repository: https://raystack.github.io/charts/
-  version: 0.5.3
-digest: sha256:d152b4844c222ecff12e0cfbe2d404241f66f2afa2f212d063df6b61584eddf0
-generated: "2024-01-31T12:19:30.82397+05:30"
+  version: 0.8.0
+- name: app
+  repository: https://raystack.github.io/charts/
+  version: 0.8.0
+digest: sha256:0560e8744c59d0cf1ba03bc02361d8d6d5eae79df335414c8ce17322c278eae5
+generated: "2025-07-01T12:28:13.75469+05:30"

--- a/stable/frontier/Chart.yaml
+++ b/stable/frontier/Chart.yaml
@@ -15,16 +15,21 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.2.0
 
 dependencies:
   - name: app
-    version: "0.6.1"
+    version: "0.8.0"
     repository: "https://raystack.github.io/charts/"
     alias: frontier-app
     condition: frontier-app.enabled
   - name: app
-    version: "0.6.1"
+    version: "0.8.0"
+    repository: "https://raystack.github.io/charts/"
+    alias: frontier-worker
+    condition: frontier-worker.enabled
+  - name: app
+    version: "0.8.0"
     repository: "https://raystack.github.io/charts/"
     alias: spicedb
     condition: spicedb.enabled

--- a/stable/frontier/values.yaml
+++ b/stable/frontier/values.yaml
@@ -3,17 +3,15 @@ frontier-app:
   image:
     repository: raystack/frontier
     pullPolicy: IfNotPresent
-    tag: v0.13.0
+    tag: v0.65.0
   container:
     command: ["frontier", "server", "start"]
     livenessProbe:
-      httpGet:
-        path: /ping
-        port: 8080
+      grpc:
+        port: 8081
     readinessProbe:
-      httpGet:
-        path: /ping
-        port: 8080
+      grpc:
+        port: 8081
     ports:
       - name: rest
         containerPort: 8080
@@ -21,21 +19,31 @@ frontier-app:
       - name: grpc
         containerPort: 8081
         protocol: TCP
+      - name: admin-ui
+        containerPort: 3000
+        protocol: TCP
+      - name: connectrpc
+        containerPort: 8082
+        protocol: TCP
   service:
     type: ClusterIP
     ports:
       - port: 8080
-        targetPort: 8080
+        targetPort: rest
         protocol: TCP
         name: tcp
       - port: 8081
-        targetPort: 8081
+        targetPort: grpc
         protocol: TCP
         name: grpc
       - port: 3000
-        targetPort: 3000
+        targetPort: admin-ui
         protocol: TCP
         name: admin-ui
+      - port: 8082
+        targetPort: connectrpc
+        protocol: TCP
+        name: connectrpc
     annotations: {}
   ingress:
     enabled: false
@@ -54,6 +62,54 @@ frontier-app:
     FRONTIER_SPICEDB_PORT: 50051
     FRONTIER_APP_PORT: 8080
     FRONTIER_APP_GRPC_PORT: 8081
+    FRONTIER_APP_CONNECT_PORT: 8082
+    FRONTIER_LOG_LEVEL: info
+    FRONTIER_DB_DRIVER: postgres
+    FRONTIER_APP_BILLING_REFRESH_INTERVAL_CUSTOMER: 0
+    FRONTIER_APP_BILLING_REFRESH_INTERVAL_SUBSCRIPTION: 0
+    FRONTIER_APP_BILLING_REFRESH_INTERVAL_CHECKOUT: 0
+    FRONTIER_APP_BILLING_REFRESH_INTERVAL_INVOICE: 0
+  secretConfig:
+    FRONTIER_DB_URL:
+    FRONTIER_SPICEDB_PRE_SHARED_KEY:
+
+frontier-worker:
+  enabled: true
+  image:
+    repository: raystack/frontier
+    pullPolicy: IfNotPresent
+    tag: v0.65.0
+  container:
+    command: ["frontier", "server", "start"]
+    livenessProbe:
+      grpc:
+        port: 8081
+    readinessProbe:
+      grpc:
+        port: 8081
+    ports:
+      - name: rest
+        containerPort: 8080
+        protocol: TCP
+      - name: grpc
+        containerPort: 8081
+        protocol: TCP
+      - name: admin-ui
+        containerPort: 3000
+        protocol: TCP
+      - name: connectrpc
+        containerPort: 8082
+        protocol: TCP
+  service:
+    enabled: false
+  ingress:
+    enabled: false
+  config:
+    FRONTIER_SPICEDB_HOST: spicedb.namespace.svc.local
+    FRONTIER_SPICEDB_PORT: 50051
+    FRONTIER_APP_PORT: 8080
+    FRONTIER_APP_GRPC_PORT: 8081
+    FRONTIER_APP_CONNECT_PORT: 8082
     FRONTIER_LOG_LEVEL: info
     FRONTIER_DB_DRIVER: postgres
   secretConfig:


### PR DESCRIPTION
This pull request adds a new `frontier-worker` component, and refining port configurations for better service alignment.

### Dependency Updates:
* Updated chart version to `0.2.0` and upgraded dependency versions for `frontier-app`, `frontier-worker`, and `spicedb` to `0.8.0`.

### Service Enhancements:
* Modified `frontier-app` service ports to include new `connectrpc` and `admin-ui` ports, aligning target ports with their respective names for improved clarity.
* Added `frontier-worker` as a new service component with similar port configurations (`rest`, `grpc`, `admin-ui`, `connectrpc`) and disabled its service and ingress by default as it will be used for background sync jobs.

### Configuration Improvements:
* Introduced new environment variables for `frontier-app`, including `FRONTIER_APP_CONNECT_PORT` and billing refresh intervals.